### PR TITLE
Correct oversights in Intellij Idea settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ bin/
 .project
 
 ### INTELLIJ IDEA ###
+.idea/
 *.iml
 *.ipr
 *.iws

--- a/build.gradle
+++ b/build.gradle
@@ -53,3 +53,5 @@ jar {
         attributes 'FMLCorePluginContainsFMLMod': 'true'
     }
 }
+
+idea.module.inheritOutputDirs = true


### PR DESCRIPTION
This commit does two things:

1) Adds idea project tree to .gitignore
2) Alters build.gradle so that resources load in the Idea development environment.

This should have no effects on people using eclipse.